### PR TITLE
change: Delete index not fail if index not exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Upgrade to elastica 3.2
 - Use codecov for coverage instead of scrutinizer
+- Delete not existing index will not throw exception anymore (replace by a info message)
 
 ## [0.2.0](https://github.com/gbprod/elastica-extra-bundle/compare/v0.1.0...v0.2.0)
 

--- a/src/ElasticaExtraBundle/Command/DeleteIndexCommand.php
+++ b/src/ElasticaExtraBundle/Command/DeleteIndexCommand.php
@@ -2,6 +2,7 @@
 
 namespace GBProd\ElasticaExtraBundle\Command;
 
+use GBProd\ElasticaExtraBundle\Exception\IndexNotFoundException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/ElasticaExtraBundle/Command/DeleteIndexCommand.php
+++ b/src/ElasticaExtraBundle/Command/DeleteIndexCommand.php
@@ -56,7 +56,14 @@ class DeleteIndexCommand extends ElasticaAwareCommand
             ->get('gbprod.elastica_extra.delete_index_handler')
         ;
 
-        $handler->handle($client, $index);
+        try {
+            $handler->handle($client, $index);
+        } catch (IndexNotFoundException $e) {
+            $output->writeln(sprintf(
+                '<info>Index "%s" not found</info>',
+                $index
+            ));
+        }
 
         $output->writeln('done');
     }

--- a/src/ElasticaExtraBundle/Exception/IndexNotFoundException.php
+++ b/src/ElasticaExtraBundle/Exception/IndexNotFoundException.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace GBProd\ElasticaExtraBundle\Exception;
+
+/**
+ * Exception thrown if index has not been found
+ *
+ * @author gbprod <contact@gb-prod.fr>
+ */
+class IndexNotFoundException extends \Exception
+{
+    /**
+     * @var string
+     */
+    private $index;
+
+    /**
+     * @param string $index
+     */
+    public function __construct($index)
+    {
+        $this->index = $index;
+    }
+
+    /**
+     * Get index name
+     *
+     * @return string
+     */
+    public function getIndex()
+    {
+        return $this->index;
+    }
+}

--- a/src/ElasticaExtraBundle/Handler/DeleteIndexHandler.php
+++ b/src/ElasticaExtraBundle/Handler/DeleteIndexHandler.php
@@ -2,6 +2,7 @@
 
 namespace GBProd\ElasticaExtraBundle\Handler;
 
+use GBProd\ElasticaExtraBundle\Exception\IndexNotFoundException;
 use Elastica\Client;
 
 /**
@@ -16,9 +17,17 @@ class DeleteIndexHandler
      *
      * @param Client $client
      * @param string $index
+     *
+     * @throws IndexNotFoundException
      */
     public function handle(Client $client, $index)
     {
-        $client->getIndex($index)->delete();
+        $index = $client->getIndex($index);
+
+        if (!$index->exists()) {
+            throw new IndexNotFoundException($index);
+        }
+
+        $index->delete();
     }
 }

--- a/tests/ElasticaExtraBundle/Exception/IndexNotFoundExceptionTest.php
+++ b/tests/ElasticaExtraBundle/Exception/IndexNotFoundExceptionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\GBProd\ElasticaExtraBundle\Exception;
+
+use GBProd\ElasticaExtraBundle\Exception\IndexNotFoundException;
+
+/**
+ * Tests for IndexNotFoundException
+ *
+ * @author gbprod <contact@gb-prod.fr>
+ */
+class IndexNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstruct()
+    {
+        $exception = new IndexNotFoundException('index');
+
+        $this->assertInstanceOf(IndexNotFoundException::class, $exception);
+        $this->assertEquals('index', $exception->getIndex());
+    }
+}


### PR DESCRIPTION
Delete index command will not throw exception anymore if index not exists.
Will display info message instead.